### PR TITLE
Use upstream `ubuntu/trusty64`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 VAGRANTFILE_API_VERSION = '2'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'trusty64'
+  config.vm.box = 'ubuntu/trusty64'
 
   # Forward ports to Apache and MySQL.
   config.vm.network 'forwarded_port', guest: 80, host: 8888


### PR DESCRIPTION
This was originally written with the assumption that `trusty64` would be
available on the host OS (as if people wouldn't have the latest version,
right?). However this wasn't always the case. Instead of expecting it to be
there, we'll point this at the upstream ubuntu VM available from Atlas.
